### PR TITLE
Set version for maven-compiler-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>


### PR DESCRIPTION
Fixes the maven build warnings:
```[WARNING] Some problems were encountered while building the effective model for com.wavefront:internal-reporter-java:jar:0.9.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 42, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.```