### PR TITLE
 Fix maven shaded plugin config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-sdk-java</artifactId>
-            <version>0.9.0</version>
+            <version>0.9.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,10 @@
                         <configuration>
                             <minimizeJar>true</minimizeJar>
                             <artifactSet>
-                                <excludes>
-                                </excludes>
+                                <includes>
+                                    <include>io.dropwizard.metrics5</include>
+                                    <include>org.slf4j</include>
+                                </includes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
@@ -100,7 +102,6 @@
             <artifactId>metrics-jvm</artifactId>
             <version>${io.dropwizard.metrics5.version}</version>
         </dependency>
-
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-sdk-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-sdk-java</artifactId>
+            <!--TODO: change the snapshot version to 1.0.0 -->
             <version>0.9.1-SNAPSHOT</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
to include only shaded classes into JAR and rest remain transitive dependencies so that we don't build Fat Jars. Also, upgrade to newer wavefront-sdk-java version so that this need not be a explicit dependency in Jersey/gRPC SDK.