### PR TITLE
Moved common application config to internal reporter Tier 2 SDK 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
             <!--TODO: change the snapshot version to 1.0.0 -->
             <version>0.9.1-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.9.7</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/com/wavefront/Main.java
+++ b/src/main/java/com/wavefront/Main.java
@@ -1,4 +1,4 @@
-package com.wavefront.internal;
+package com.wavefront;
 
 import com.wavefront.internal.reporter.WavefrontInternalReporter;
 import com.wavefront.sdk.direct_ingestion.WavefrontDirectIngestionClient;

--- a/src/main/java/com/wavefront/config/ApplicationTags.java
+++ b/src/main/java/com/wavefront/config/ApplicationTags.java
@@ -1,0 +1,76 @@
+package com.wavefront.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Application Tags YAML Config.
+ *
+ * @author Sushant Dewan (sushant@wavefront.com).
+ */
+public class ApplicationTags {
+
+  /**
+   * Name of the application.
+   */
+  @Nonnull
+  @JsonProperty
+  private String application = "defaultApplication";
+
+  /**
+   * Name of the service.
+   */
+  @Nonnull
+  @JsonProperty
+  private String service = "defaultService";
+
+  /**
+   * Cluster where the service is running in.
+   */
+  @Nullable
+  @JsonProperty
+  private String cluster;
+
+  /**
+   * Shard where the service is running on.
+   */
+  @Nullable
+  @JsonProperty
+  private String shard;
+
+  /**
+   * Additional metadata.
+   */
+  @Nullable
+  @JsonProperty
+  Map<String, String> customTags;
+
+  @Nonnull
+  public String getApplication() {
+    return application;
+  }
+
+  @Nonnull
+  public String getService() {
+    return service;
+  }
+
+  @Nullable
+  public String getCluster() {
+    return cluster;
+  }
+
+  @Nullable
+  public String getShard() {
+    return shard;
+  }
+
+  @Nullable
+  public Map<String, String> getCustomTags() {
+    return customTags;
+  }
+}

--- a/src/main/java/com/wavefront/config/ApplicationTagsConfig.java
+++ b/src/main/java/com/wavefront/config/ApplicationTagsConfig.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
  *
  * @author Sushant Dewan (sushant@wavefront.com).
  */
-public class ApplicationTags {
+public class ApplicationTagsConfig {
 
   /**
    * Name of the application.

--- a/src/main/java/com/wavefront/config/WavefrontReportingConfig.java
+++ b/src/main/java/com/wavefront/config/WavefrontReportingConfig.java
@@ -1,0 +1,99 @@
+package com.wavefront.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Configuration for reporting telemetry to wavefront either through direct ingestion or through
+ * wavefront proxy.
+ *
+ * @author Srujan Narkedamalli (snarkedamall@wavefront.com).
+ */
+public class WavefrontReportingConfig {
+
+  public final static String proxyReporting = "proxy";
+  public final static String directReporting = "direct";
+
+  /**
+   * Reporting mechanism to be used to send telemetry to Wavefront.
+   */
+  @JsonProperty
+  @Nonnull
+  private String reportingMechanism;
+
+  /**
+   * Wavefront server to be used for direct ingestion.
+   */
+  @JsonProperty
+  private String server;
+
+  /**
+   *  Wavefront API token for direct ingestion.
+   */
+  @JsonProperty
+  private String token;
+
+  /**
+   * Proxy host for proxy ingestion.
+   */
+  @JsonProperty
+  private String proxyHost;
+
+  /**
+   * Proxy port for metrics ingestion.
+   */
+  @JsonProperty
+  private int proxyMetricsPort;
+
+  /**
+   * Proxy port for distributions ingestion.
+   */
+  @JsonProperty
+  private int proxyDistributionsPort;
+
+  /**
+   * Proxy port for trace/span ingestion.
+   */
+  @JsonProperty
+  private int proxyTracingPort;
+
+  /**
+   * Interval at which to report telemetry data.
+   */
+  @JsonProperty
+  private int flushIntervalSeconds = 10;
+
+  @Nonnull
+  public String getReportingMechanism() {
+    return reportingMechanism;
+  }
+
+  public String getServer() {
+    return server;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public String getProxyHost() {
+    return proxyHost;
+  }
+
+  public int getProxyMetricsPort() {
+    return proxyMetricsPort;
+  }
+
+  public int getProxyDistributionsPort() {
+    return proxyDistributionsPort;
+  }
+
+  public int getFlushIntervalSeconds() {
+    return flushIntervalSeconds;
+  }
+
+  public int getProxyTracingPort() {
+    return proxyTracingPort;
+  }
+}

--- a/src/main/java/com/wavefront/config/WavefrontReportingConfig.java
+++ b/src/main/java/com/wavefront/config/WavefrontReportingConfig.java
@@ -58,12 +58,6 @@ public class WavefrontReportingConfig {
   @JsonProperty
   private int proxyTracingPort;
 
-  /**
-   * Interval at which to report telemetry data.
-   */
-  @JsonProperty
-  private int flushIntervalSeconds = 10;
-
   @Nonnull
   public String getReportingMechanism() {
     return reportingMechanism;
@@ -87,10 +81,6 @@ public class WavefrontReportingConfig {
 
   public int getProxyDistributionsPort() {
     return proxyDistributionsPort;
-  }
-
-  public int getFlushIntervalSeconds() {
-    return flushIntervalSeconds;
   }
 
   public int getProxyTracingPort() {


### PR DESCRIPTION
Example of ApplicationTags below -
applicationTags:
  application: beachshirts
  cluster: us-west
  service: styling
  shard: primary
  customTags:
    location: Palo-Alto
    env: production

Example of Direct ingestion reporter below -
wavefrontReportingConfig:
  reportingMechanism: "direct"
  server: "<replace-with-wavefront-url>"
  token: "<API_TOKEN>
  flushIntervalSeconds: 5

Example of Proxy reporter below -
wavefrontReportingConfig:
  reportingMechanism: "proxy"
  proxyHost: "<replace-with-wavefront-url>"
  proxyMetricsPort: 2878
  proxyDistributionsPort: 40000
  proxyTracingPort: 30000
  flushIntervalSeconds: 10