### PR TITLE
Add span derived metrics generation support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,12 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.9.10.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.3.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -220,9 +220,9 @@
             <version>2.9.10.3</version>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.3.1</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/wavefront/internal/SpanDerivedMetricsUtils.java
+++ b/src/main/java/com/wavefront/internal/SpanDerivedMetricsUtils.java
@@ -109,8 +109,8 @@ public class SpanDerivedMetricsUtils {
           if (traceDerivedCustomTagKeys.contains(tagKey)) {
             pointTags.put(tagKey, tagValue);
           }
-          // propagate http status if the span has error
-          if (isError && tagKey.equalsIgnoreCase(HTTP_STATUS_KEY)) {
+          // propagate http status
+          if (tagKey.equalsIgnoreCase(HTTP_STATUS_KEY)) {
             pointTags.put(HTTP_STATUS_KEY, tagValue);
           }
         });

--- a/src/main/java/com/wavefront/internal/SpanDerivedMetricsUtils.java
+++ b/src/main/java/com/wavefront/internal/SpanDerivedMetricsUtils.java
@@ -1,0 +1,207 @@
+package com.wavefront.internal;
+
+import com.wavefront.internal.reporter.WavefrontInternalReporter;
+import com.wavefront.java_sdk.com.google.common.annotations.VisibleForTesting;
+import com.wavefront.sdk.common.Pair;
+import com.wavefront.sdk.common.WavefrontSender;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import io.dropwizard.metrics5.MetricName;
+
+import static com.wavefront.sdk.common.Constants.APPLICATION_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.CLUSTER_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.COMPONENT_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.HEART_BEAT_METRIC;
+import static com.wavefront.sdk.common.Constants.SERVICE_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.SHARD_TAG_KEY;
+import static com.wavefront.sdk.common.Constants.SOURCE_KEY;
+import static com.wavefront.sdk.common.Constants.NULL_TAG_VAL;
+import static com.wavefront.sdk.common.Utils.sanitizeWithoutQuotes;
+
+/**
+ * Util methods to generate data (metrics/histograms/heartbeats) from tracing spans
+ *
+ * @author Hao Song (songhao@vmware.com).
+ */
+public class SpanDerivedMetricsUtils {
+
+  public final static String TRACING_DERIVED_PREFIX = "tracing.derived";
+  public final static String ERROR_SPAN_TAG_KEY = "error";
+  public final static String ERROR_SPAN_TAG_VAL = "true";
+  public final static String DEBUG_SPAN_TAG_KEY = "debug";
+  public final static String DEBUG_SPAN_TAG_VAL = "true";
+
+  private final static String INVOCATION_SUFFIX = ".invocation";
+  private final static String ERROR_SUFFIX = ".error";
+  private final static String DURATION_SUFFIX = ".duration.micros";
+  private final static String TOTAL_TIME_SUFFIX = ".total_time.millis";
+  private final static String OPERATION_NAME_TAG = "operationName";
+  private static final String SPAN_KIND_KEY = "span.kind";
+  private static final String HTTP_STATUS_KEY = "http.status_code";
+
+  /**
+   * Report generated metrics and histograms from the wavefront tracing span.
+   *
+   * @param operationName             span operation name.
+   * @param application               name of the application.
+   * @param service                   name of the service.
+   * @param cluster                   name of the cluster.
+   * @param shard                     name of the shard.
+   * @param source                    reporting source.
+   * @param componentTagValue         component tag value.
+   * @param isError                   indicates if the span is erroneous.
+   * @param spanDurationMicros        Original span duration (both Zipkin and Jaeger support micros
+   *                                  duration).
+   * @param traceDerivedCustomTagKeys custom tags added to derived RED metrics.
+   * @param spanTags                  span tags.
+   * @return Pair of Heartbeat custom tags and source.
+   */
+  @Nonnull
+  public static Pair<Map<String, String>, String> reportWavefrontGeneratedData(
+      @Nonnull WavefrontInternalReporter wfInternalReporter, @Nonnull String operationName,
+      @Nonnull String application, @Nonnull String service, String cluster, String shard,
+      String source, String componentTagValue, boolean isError, long spanDurationMicros,
+      Set<String> traceDerivedCustomTagKeys, List<Pair<String, String>> spanTags) {
+    return reportWavefrontGeneratedData(wfInternalReporter, operationName, application, service,
+        cluster, shard, source, componentTagValue, isError, spanDurationMicros,
+        traceDerivedCustomTagKeys, spanTags, System::currentTimeMillis);
+  }
+
+  @VisibleForTesting
+  @Nonnull
+  protected static Pair<Map<String, String>, String> reportWavefrontGeneratedData(
+      @Nonnull WavefrontInternalReporter wfInternalReporter, String operationName, String application,
+      String service, String cluster, String shard, String source, String componentTagValue,
+      boolean isError, long spanDurationMicros, Set<String> traceDerivedCustomTagKeys,
+      List<Pair<String, String>> spanTags, Supplier<Long> clock) {
+
+    Map<String, String> pointTags = new HashMap<>();
+    source = getNonEmptyOrDefaultValue(source, "unknown_source");
+
+    try {
+      /*
+       * 1) Can only propagate mandatory application/service and optional cluster/shard tags.
+       * 2) Cannot convert ApplicationTags.customTags unfortunately as those are not well-known.
+       * 3) Both Jaeger and Zipkin support error=true tag for erroneous spans
+       */
+      pointTags.put(APPLICATION_TAG_KEY, getNonEmptyOrDefaultValue(application, "unknown_application"));
+      pointTags.put(SERVICE_TAG_KEY, getNonEmptyOrDefaultValue(service, "unknown_service"));
+      pointTags.put(CLUSTER_TAG_KEY, getNonEmptyOrDefaultValue(cluster, NULL_TAG_VAL));
+      pointTags.put(SHARD_TAG_KEY, getNonEmptyOrDefaultValue(shard, NULL_TAG_VAL));
+      pointTags.put(OPERATION_NAME_TAG, getNonEmptyOrDefaultValue(operationName, "unknown_operation"));
+      pointTags.put(COMPONENT_TAG_KEY, getNonEmptyOrDefaultValue(componentTagValue, NULL_TAG_VAL));
+      pointTags.put(SOURCE_KEY, source);
+
+      if (traceDerivedCustomTagKeys != null && traceDerivedCustomTagKeys.size() > 0) {
+        spanTags.forEach((tag) -> {
+          String tagKey = tag._1;
+          String tagValue = tag._2;
+          if (traceDerivedCustomTagKeys.contains(tagKey)) {
+            pointTags.put(tagKey, tagValue);
+          }
+          // propagate http status if the span has error
+          if (isError && tagKey.equalsIgnoreCase(HTTP_STATUS_KEY)) {
+            pointTags.put(HTTP_STATUS_KEY, tagValue);
+          }
+        });
+      }
+
+      // span.kind tag will be promoted by default
+      pointTags.putIfAbsent(SPAN_KIND_KEY, NULL_TAG_VAL);
+
+      // tracing.derived.<application>.<service>.<operation>.invocation.count
+      wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
+          "." + service + "." + operationName + INVOCATION_SUFFIX), pointTags)).inc();
+
+      if (isError) {
+        // tracing.derived.<application>.<service>.<operation>.error.count
+        wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
+            "." + service + "." + operationName + ERROR_SUFFIX), pointTags)).inc();
+      }
+
+      // tracing.derived.<application>.<service>.<operation>.duration.micros.m
+      if (isError) {
+        Map<String, String> errorPointTags = new HashMap<>(pointTags);
+        errorPointTags.put("error", "true");
+        wfInternalReporter.newWavefrontHistogram(new MetricName(sanitizeWithoutQuotes(application +
+            "." + service + "." + operationName + DURATION_SUFFIX), errorPointTags), clock).
+            update(spanDurationMicros);
+      } else {
+        wfInternalReporter.newWavefrontHistogram(new MetricName(sanitizeWithoutQuotes(application +
+            "." + service + "." + operationName + DURATION_SUFFIX), pointTags), clock).
+            update(spanDurationMicros);
+      }
+
+      // tracing.derived.<application>.<service>.<operation>.total_time.millis.count
+      wfInternalReporter.newDeltaCounter(new MetricName(sanitizeWithoutQuotes(application +
+          "." + service + "." + operationName + TOTAL_TIME_SUFFIX), pointTags)).
+          inc(spanDurationMicros / 1000);
+
+      // Remove operation tag and source tag from tags list before sending RED heartbeat.
+      pointTags.remove(OPERATION_NAME_TAG);
+      pointTags.remove(SOURCE_KEY);
+    } catch (Exception ignored) {
+      // This should never happen, if all SDKs version are set properly.
+    }
+    return new Pair<>(pointTags, source);
+  }
+
+  /**
+   * Report discovered heartbeats to Wavefront.
+   *
+   * @param wavefrontSender            Wavefront sender via proxy.
+   * @param discoveredHeartbeatMetrics Discovered heartbeats.
+   */
+  public static void reportHeartbeats(WavefrontSender wavefrontSender,
+                                      Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics) throws IOException {
+    reportHeartbeats(wavefrontSender, discoveredHeartbeatMetrics, null);
+  }
+
+  /**
+   * Report discovered heartbeats to Wavefront.
+   *
+   * @param wavefrontSender            Wavefront sender via proxy.
+   * @param discoveredHeartbeatMetrics Discovered heartbeats.
+   * @param extraComponent             Extra component value need to be sent in heartbeats metric.
+   */
+  public static void reportHeartbeats(WavefrontSender wavefrontSender,
+                                      Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics,
+                                      @Nullable String extraComponent) throws IOException {
+    if (wavefrontSender == null) {
+      // should never happen
+      return;
+    }
+    Iterator<Pair<Map<String, String>, String>> iter = discoveredHeartbeatMetrics.iterator();
+    while (iter.hasNext()) {
+      Pair<Map<String, String>, String> key = iter.next();
+
+      Map<String, String> tags = new HashMap<>(key._1);
+      String source = key._2;
+
+      wavefrontSender.sendMetric(HEART_BEAT_METRIC, 1.0, System.currentTimeMillis(), source, tags);
+      if (extraComponent != null && !extraComponent.trim().isEmpty()) {
+        tags.put(COMPONENT_TAG_KEY, extraComponent);
+        wavefrontSender.sendMetric(HEART_BEAT_METRIC, 1.0, System.currentTimeMillis(), source, tags);
+      }
+      // remove from discovered list so that it is only reported on subsequent discovery
+      discoveredHeartbeatMetrics.remove(key);
+    }
+  }
+
+  private static String getNonEmptyOrDefaultValue(String inputValue, String defaultValue) {
+    if (inputValue == null || inputValue.trim().isEmpty()) {
+      return defaultValue;
+    }
+    return inputValue;
+  }
+}

--- a/src/main/java/com/wavefront/internal/SpanDerivedMetricsUtils.java
+++ b/src/main/java/com/wavefront/internal/SpanDerivedMetricsUtils.java
@@ -64,6 +64,7 @@ public class SpanDerivedMetricsUtils {
    *                                  duration).
    * @param traceDerivedCustomTagKeys custom tags added to derived RED metrics.
    * @param spanTags                  span tags.
+   * @param isReportingDelta          reporting delta counters or normal counters.
    * @return Pair of Heartbeat custom tags and source.
    */
   @Nonnull
@@ -144,7 +145,8 @@ public class SpanDerivedMetricsUtils {
 
     // tracing.derived.<application>.<service>.<operation>.total_time.millis.count
     incCounter(wfInternalReporter, new MetricName(sanitizeWithoutQuotes(application +
-        "." + service + "." + operationName + TOTAL_TIME_SUFFIX), pointTags), isReportingDelta, spanDurationMicros / 1000);
+        "." + service + "." + operationName + TOTAL_TIME_SUFFIX), pointTags), isReportingDelta,
+        spanDurationMicros / 1000);
 
     // Remove operation tag and source tag from tags list before sending RED heartbeat.
     pointTags.remove(OPERATION_NAME_TAG);
@@ -174,7 +176,8 @@ public class SpanDerivedMetricsUtils {
    * @param discoveredHeartbeatMetrics Discovered heartbeats.
    */
   public static void reportHeartbeats(WavefrontSender wavefrontSender,
-                                      Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics) throws IOException {
+                                      Set<Pair<Map<String, String>, String>> discoveredHeartbeatMetrics)
+      throws IOException {
     reportHeartbeats(wavefrontSender, discoveredHeartbeatMetrics, "");
   }
 

--- a/src/test/java/com/wavefront/internal/SpanDerivedMetricsUtilsTest.java
+++ b/src/test/java/com/wavefront/internal/SpanDerivedMetricsUtilsTest.java
@@ -10,9 +10,9 @@ import com.wavefront.sdk.common.annotation.Nullable;
 import com.wavefront.sdk.entities.histograms.HistogramGranularity;
 import com.wavefront.sdk.entities.tracing.SpanLog;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
@@ -32,7 +32,7 @@ import static com.wavefront.internal.SpanDerivedMetricsUtils.reportWavefrontGene
 import static com.wavefront.sdk.common.Constants.HEART_BEAT_METRIC;
 import static com.wavefront.sdk.common.Utils.histogramToLineData;
 import static com.wavefront.sdk.common.Utils.metricToLineData;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Unit tests for {@link SpanDerivedMetricsUtils}.
@@ -152,8 +152,8 @@ public class SpanDerivedMetricsUtilsTest {
     }
   }
 
-  @BeforeAll
-  static void setUpAll() {
+  @BeforeClass
+  public static void classSetup() {
     wavefrontSender = new WavefrontSender() {
       @Override
       public String getClientId() {
@@ -212,7 +212,7 @@ public class SpanDerivedMetricsUtilsTest {
     };
   }
 
-  @BeforeEach
+  @Before
   public void setUp() throws IOException {
     // Clear metrics and histograms records.
     wavefrontSender.flush();

--- a/src/test/java/com/wavefront/internal/SpanDerivedMetricsUtilsTest.java
+++ b/src/test/java/com/wavefront/internal/SpanDerivedMetricsUtilsTest.java
@@ -1,0 +1,448 @@
+package com.wavefront.internal;
+
+import com.wavefront.internal.reporter.WavefrontInternalReporter;
+import com.wavefront.java_sdk.com.google.common.collect.ImmutableList;
+import com.wavefront.java_sdk.com.google.common.collect.ImmutableSet;
+import com.wavefront.java_sdk.com.google.common.collect.Sets;
+import com.wavefront.sdk.common.Pair;
+import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.common.annotation.Nullable;
+import com.wavefront.sdk.entities.histograms.HistogramGranularity;
+import com.wavefront.sdk.entities.tracing.SpanLog;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.wavefront.internal.SpanDerivedMetricsUtils.reportHeartbeats;
+import static com.wavefront.internal.SpanDerivedMetricsUtils.reportWavefrontGeneratedData;
+import static com.wavefront.sdk.common.Constants.HEART_BEAT_METRIC;
+import static com.wavefront.sdk.common.Utils.histogramToLineData;
+import static com.wavefront.sdk.common.Utils.metricToLineData;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link SpanDerivedMetricsUtils}.
+ *
+ * @author Hao Song (songhao@vmware.com).
+ */
+public class SpanDerivedMetricsUtilsTest {
+
+  private static WavefrontSender wavefrontSender;
+  private static WavefrontInternalReporter wavefrontInternalReporter;
+  private static AtomicLong wavefrontHistogramClock;
+  private static final Set<MetricRecord> heartbeatMetricsEmitted = new HashSet<>();
+  private static final Set<MetricRecord> metricsEmitted = new HashSet<>();
+  private static final Set<HistogramRecord> histogramsEmitted = new HashSet<>();
+
+  static class MetricRecord {
+    String name;
+    double value;
+    @Nullable
+    String source;
+    @Nullable
+    Map<String, String> tags;
+
+    public MetricRecord(String name, double value, @Nullable String source, @Nullable Map<String, String> tags) {
+      this.name = name;
+      this.value = value;
+      this.source = source;
+      this.tags = tags;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      MetricRecord that = (MetricRecord) o;
+
+      if (Double.compare(that.value, value) != 0) return false;
+      if (!Objects.equals(name, that.name)) return false;
+      if (!Objects.equals(source, that.source)) return false;
+      return Objects.equals(tags, that.tags);
+    }
+
+    @Override
+    public int hashCode() {
+      int result;
+      long temp;
+      result = name != null ? name.hashCode() : 0;
+      temp = Double.doubleToLongBits(value);
+      result = 31 * result + (int) (temp ^ (temp >>> 32));
+      result = 31 * result + (source != null ? source.hashCode() : 0);
+      result = 31 * result + (tags != null ? tags.hashCode() : 0);
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return metricToLineData(name, value,  null, source, tags, "default-source");
+    }
+  }
+
+  static class HistogramRecord {
+    String name;
+    List<Pair<Double, Integer>> centroids;
+    Set<HistogramGranularity> histogramGranularities;
+    @Nullable
+    Long timestamp;
+    @Nullable
+    String source;
+    @Nullable
+    Map<String, String> tags;
+
+    public HistogramRecord(String name, List<Pair<Double, Integer>> centroids,
+                           Set<HistogramGranularity> histogramGranularities, @Nullable Long timestamp,
+                           @Nullable String source, @Nullable Map<String, String> tags) {
+      this.name = name;
+      this.centroids = centroids;
+      this.histogramGranularities = histogramGranularities;
+      this.timestamp = timestamp;
+      this.source = source;
+      this.tags = tags;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      HistogramRecord that = (HistogramRecord) o;
+
+      if (!Objects.equals(name, that.name)) return false;
+      if (!Objects.equals(centroids, that.centroids))
+        return false;
+      if (!Objects.equals(histogramGranularities, that.histogramGranularities))
+        return false;
+      if (!Objects.equals(timestamp, that.timestamp))
+        return false;
+      if (!Objects.equals(source, that.source)) return false;
+      return Objects.equals(tags, that.tags);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = name != null ? name.hashCode() : 0;
+      result = 31 * result + (centroids != null ? centroids.hashCode() : 0);
+      result = 31 * result + (histogramGranularities != null ? histogramGranularities.hashCode() : 0);
+      result = 31 * result + (timestamp != null ? timestamp.hashCode() : 0);
+      result = 31 * result + (source != null ? source.hashCode() : 0);
+      result = 31 * result + (tags != null ? tags.hashCode() : 0);
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return histogramToLineData(name, centroids, histogramGranularities, timestamp, source, tags,
+          "default-source");
+    }
+  }
+
+  @BeforeAll
+  static void setUpAll() {
+    wavefrontSender = new WavefrontSender() {
+      @Override
+      public String getClientId() {
+        return "";
+      }
+
+      @Override
+      public void flush() {
+        metricsEmitted.clear();
+        histogramsEmitted.clear();
+      }
+
+      @Override
+      public int getFailureCount() {
+        return 0;
+      }
+
+      @Override
+      public void sendDistribution(String name, List<Pair<Double, Integer>> centroids,
+                                   Set<HistogramGranularity> histogramGranularities,
+                                   @Nullable Long timestamp, @Nullable String source,
+                                   @Nullable Map<String, String> tags) {
+        HistogramRecord histogramRecord = new HistogramRecord(name, centroids,
+            histogramGranularities, timestamp, source, tags);
+        histogramsEmitted.add(histogramRecord);
+      }
+
+      @Override
+      public void sendMetric(String name, double value, @Nullable Long timestamp,
+                             @Nullable String source, @Nullable Map<String, String> tags) {
+        MetricRecord metricRecord = new MetricRecord(name, value, source, tags);
+        if (name.equalsIgnoreCase(HEART_BEAT_METRIC)) {
+          heartbeatMetricsEmitted.add(metricRecord);
+        } else {
+          metricsEmitted.add(metricRecord);
+        }
+      }
+
+      @Override
+      public void sendFormattedMetric(String point) {
+        throw new NotImplementedException();
+      }
+
+      @Override
+      public void sendSpan(String name, long startMillis, long durationMillis, @Nullable String source,
+                           UUID traceId, UUID spanId, @Nullable List<UUID> parents,
+                           @Nullable List<UUID> followsFrom, @Nullable List<Pair<String, String>> tags,
+                           @Nullable List<SpanLog> spanLogs) {
+        throw new NotImplementedException();
+      }
+
+      @Override
+      public void close() {
+        this.flush();
+      }
+    };
+  }
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    // Clear metrics and histograms records.
+    wavefrontSender.flush();
+
+    // Realign the clock to System.currentTimeMillis().
+    wavefrontHistogramClock = new AtomicLong(System.currentTimeMillis());
+
+    // Reset wavefrontInternalReporter.
+    wavefrontInternalReporter = new WavefrontInternalReporter.Builder().
+        prefixedWith("tracing.derived").withSource("default-source").reportMinuteDistribution().
+        build(wavefrontSender);
+  }
+
+  @Test
+  public void testHeartbeatMetrics() throws IOException {
+    Pair<Map<String, String>, String> heartbeatTags = reportWavefrontGeneratedData(
+        wavefrontInternalReporter, "orderShirt", "beachshirts", "shopping", "us-west", "primary",
+        "localhost", "jdbc", false, 10000L, Sets.newHashSet("location"),
+        ImmutableList.of(new Pair<>("location", "SF")), () -> wavefrontHistogramClock.get());
+
+    // Assert return pointTags of Heartbeat metrics.
+    assertEquals(Stream.of(new String[][]{
+        {"component", "jdbc"},
+        {"application", "beachshirts"},
+        {"service", "shopping"},
+        {"cluster", "us-west"},
+        {"shard", "primary"},
+        {"span.kind", "none"},
+        {"location", "SF"}
+    }).collect(Collectors.toMap(data -> data[0], data -> data[1])), heartbeatTags._1);
+
+    // Assert return source value of Heartbeat metrics.
+    assertEquals("localhost", heartbeatTags._2);
+
+    reportHeartbeats(wavefrontSender, Sets.newHashSet(heartbeatTags));
+
+    Set<MetricRecord> heatbeatMetricsExpected = new HashSet<>();
+    heatbeatMetricsExpected.add(new MetricRecord(
+        "~component.heartbeat",
+        1.0,
+        "localhost",
+        Stream.of(new String[][]{
+            {"component", "jdbc"},
+            {"application", "beachshirts"},
+            {"service", "shopping"},
+            {"cluster", "us-west"},
+            {"shard", "primary"},
+            {"span.kind", "none"},
+            {"location", "SF"}
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]))));
+    assertEquals(heatbeatMetricsExpected, heartbeatMetricsEmitted);
+    heartbeatMetricsEmitted.clear();
+
+    reportHeartbeats(wavefrontSender, Sets.newHashSet(heartbeatTags), "jaeger");
+    heatbeatMetricsExpected.add(new MetricRecord(
+        "~component.heartbeat",
+        1.0,
+        "localhost",
+        Stream.of(new String[][]{
+            {"component", "jaeger"},
+            {"application", "beachshirts"},
+            {"service", "shopping"},
+            {"cluster", "us-west"},
+            {"shard", "primary"},
+            {"span.kind", "none"},
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]))));
+    assertEquals(2, heartbeatMetricsEmitted.size());
+  }
+
+  @Test
+  public void testNonErroneousSpanRedMetrics() {
+    reportWavefrontGeneratedData(
+        wavefrontInternalReporter, "orderShirt", "beachshirts", "shopping", "us-west", "primary",
+        "localhost", "jdbc", false, 10000L, Sets.newHashSet("location"),
+        ImmutableList.of(new Pair<>("location", "SF")), () -> wavefrontHistogramClock.get());
+    long histogramEmittedMinuteMillis = (wavefrontHistogramClock.get() / 60000L) * 60000L;
+
+    wavefrontHistogramClock.addAndGet(60000L + 1);
+    wavefrontInternalReporter.report();
+
+    Set<MetricRecord> metricExpected = new HashSet<>();
+    Set<HistogramRecord> histogramExpected = new HashSet<>();
+
+    metricExpected.add(new MetricRecord(
+        "∆tracing.derived.beachshirts.shopping.orderShirt.invocation.count",
+        1.0,
+        "default-source",
+        Stream.of(new String[][]{
+            {"component", "jdbc"},
+            {"application", "beachshirts"},
+            {"service", "shopping"},
+            {"cluster", "us-west"},
+            {"shard", "primary"},
+            {"operationName", "orderShirt"},
+            {"span.kind", "none"},
+            {"source", "localhost"},
+            {"location", "SF"}
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]))));
+
+    metricExpected.add(new MetricRecord(
+        "∆tracing.derived.beachshirts.shopping.orderShirt.total_time.millis.count",
+        10.0,
+        "default-source",
+        Stream.of(new String[][]{
+            {"component", "jdbc"},
+            {"application", "beachshirts"},
+            {"service", "shopping"},
+            {"cluster", "us-west"},
+            {"shard", "primary"},
+            {"operationName", "orderShirt"},
+            {"span.kind", "none"},
+            {"source", "localhost"},
+            {"location", "SF"}
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+    ));
+
+    histogramExpected.add(new HistogramRecord(
+        "tracing.derived.beachshirts.shopping.orderShirt.duration.micros",
+        ImmutableList.of(new Pair<>(10000.0, 1)),
+        ImmutableSet.of(HistogramGranularity.MINUTE),
+        histogramEmittedMinuteMillis,
+        "default-source",
+        Stream.of(new String[][]{
+            {"component", "jdbc"},
+            {"application", "beachshirts"},
+            {"service", "shopping"},
+            {"cluster", "us-west"},
+            {"shard", "primary"},
+            {"operationName", "orderShirt"},
+            {"span.kind", "none"},
+            {"source", "localhost"},
+            {"location", "SF"}
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+    ));
+
+    // Assert metrics data part of RED metrics.
+    assertEquals(metricExpected, metricsEmitted);
+
+    // Assert histogram data part of RED metrics.
+    assertEquals(histogramExpected, histogramsEmitted);
+  }
+
+  @Test
+  public void testErroneousSpanRedMetrics() {
+    reportWavefrontGeneratedData(
+        wavefrontInternalReporter, "orderShirt", "beachshirts", "shopping", "us-west", "primary",
+        "localhost", "jdbc", true, 10000L, Sets.newHashSet("location"),
+        ImmutableList.of(new Pair<>("location", "SF")), () -> wavefrontHistogramClock.get());
+    long histogramEmittedMinuteMillis = (wavefrontHistogramClock.get() / 60000L) * 60000L;
+
+    wavefrontHistogramClock.addAndGet(60000L + 1);
+    wavefrontInternalReporter.report();
+
+    Set<MetricRecord> metricExpected = new HashSet<>();
+    Set<HistogramRecord> histogramExpected = new HashSet<>();
+
+    metricExpected.add(new MetricRecord(
+        "∆tracing.derived.beachshirts.shopping.orderShirt.invocation.count",
+        1.0,
+        "default-source",
+        Stream.of(new String[][]{
+            {"component", "jdbc"},
+            {"application", "beachshirts"},
+            {"service", "shopping"},
+            {"cluster", "us-west"},
+            {"shard", "primary"},
+            {"operationName", "orderShirt"},
+            {"span.kind", "none"},
+            {"source", "localhost"},
+            {"location", "SF"}
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]))));
+
+    metricExpected.add(new MetricRecord(
+        "∆tracing.derived.beachshirts.shopping.orderShirt.error.count",
+        1.0,
+        "default-source",
+        Stream.of(new String[][]{
+            {"component", "jdbc"},
+            {"application", "beachshirts"},
+            {"service", "shopping"},
+            {"cluster", "us-west"},
+            {"shard", "primary"},
+            {"operationName", "orderShirt"},
+            {"span.kind", "none"},
+            {"source", "localhost"},
+            {"location", "SF"}
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+    ));
+
+    metricExpected.add(new MetricRecord(
+        "∆tracing.derived.beachshirts.shopping.orderShirt.total_time.millis.count",
+        10.0,
+        "default-source",
+        Stream.of(new String[][]{
+            {"component", "jdbc"},
+            {"application", "beachshirts"},
+            {"service", "shopping"},
+            {"cluster", "us-west"},
+            {"shard", "primary"},
+            {"operationName", "orderShirt"},
+            {"span.kind", "none"},
+            {"source", "localhost"},
+            {"location", "SF"}
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+    ));
+
+    histogramExpected.add(new HistogramRecord(
+        "tracing.derived.beachshirts.shopping.orderShirt.duration.micros",
+        ImmutableList.of(new Pair<>(10000.0, 1)),
+        ImmutableSet.of(HistogramGranularity.MINUTE),
+        histogramEmittedMinuteMillis,
+        "default-source",
+        Stream.of(new String[][]{
+            {"component", "jdbc"},
+            {"application", "beachshirts"},
+            {"service", "shopping"},
+            {"cluster", "us-west"},
+            {"shard", "primary"},
+            {"operationName", "orderShirt"},
+            {"span.kind", "none"},
+            {"source", "localhost"},
+            {"error", "true"},
+            {"location", "SF"}
+        }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+    ));
+
+    // Assert metrics data part of RED metrics.
+    assertEquals(metricExpected, metricsEmitted);
+
+    // Assert histogram data part of RED metrics.
+    assertEquals(histogramExpected, histogramsEmitted);
+  }
+}


### PR DESCRIPTION
Add span derived metrics generation support, will be consumed by:
- Wavefront Opentracing SDK Java
- Wavefront Proxy
- Wavefront Springboot SDK