### PR TITLE
Update jackson version to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <developerConnection>scm:git:git@github.com:wavefrontHQ/wavefront-internal-reporter-java.git</developerConnection>
         <url>git@github.com:wavefrontHQ/wavefront-internal-reporter-java.git</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <distributionManagement>
         <snapshotRepository>
@@ -44,6 +44,7 @@
         <io.dropwizard.metrics5.version>5.0.0-rc2</io.dropwizard.metrics5.version>
         <slf4j.version>1.7.25</slf4j.version>
         <java.version>1.8</java.version>
+        <jackson.version>2.11.0</jackson.version>
     </properties>
 
     <build>
@@ -216,17 +217,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.10</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.9.10</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0.pr1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/java/com/wavefront/internal/SpanDerivedMetricsUtilsTest.java
+++ b/src/test/java/com/wavefront/internal/SpanDerivedMetricsUtilsTest.java
@@ -14,8 +14,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -199,7 +197,7 @@ public class SpanDerivedMetricsUtilsTest {
 
       @Override
       public void sendFormattedMetric(String point) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
       }
 
       @Override
@@ -207,7 +205,7 @@ public class SpanDerivedMetricsUtilsTest {
                            UUID traceId, UUID spanId, @Nullable List<UUID> parents,
                            @Nullable List<UUID> followsFrom, @Nullable List<Pair<String, String>> tags,
                            @Nullable List<SpanLog> spanLogs) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
       }
 
       @Override


### PR DESCRIPTION
Updating jackson dependencies to be the same version (2.11.0 to match proxy) to resolve failing build for https://github.com/wavefrontHQ/wavefront-opentracing-bundle-java