### PR TITLE
Unshade slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,17 +94,12 @@
                             <artifactSet>
                                 <includes>
                                     <include>io.dropwizard.metrics5</include>
-                                    <include>org.slf4j</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>io.dropwizard.metrics5</pattern>
                                     <shadedPattern>com.wavefront.internal_reporter_java.io.dropwizard.metrics5</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.slf4j</pattern>
-                                    <shadedPattern>com.wavefront.internal_reporter_java.org.slf4j</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>


### PR DESCRIPTION
Allow users to independently bump to newer versions of slf4j for security and compliance reasons.

We are leaving dropwizard metrics shaded since we extended that namespace with `io.dropwizard.metrics5.DeltaCounter` and `io.dropwizard.metrics5.WavefrontHistogram`, which themselves are used in various codebases.