### PR TITLE
Remove `slf4j-nop` dependency

### DIFF
--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -45,8 +45,6 @@ SECTION 1: Apache License, V2.0
 SECTION 2: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
 
    >>> org.checkerframework:checker-qual-2.10.0
-   >>> org.slf4j:slf4j-api-1.7.30
-   >>> org.slf4j:slf4j-nop-1.7.30
 
 
 SECTION 3: Creative Commons Attribution 2.5
@@ -303,54 +301,6 @@ BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES are applicable to the following 
 >>> org.checkerframework:checker-qual-2.10.0
 
 License: MIT
-
->>> org.slf4j:slf4j-api-1.7.30
-
-Copyright (c) 2004-2011 QOS.ch
-All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy  of this  software  and  associated  documentation files  (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
->>> org.slf4j:slf4j-nop-1.7.30
-
-Copyright (c) 2004-2011 QOS.ch
-All rights reserved.
-
-Permission is hereby granted, free  of charge, to any person obtaining
-a  copy  of this  software  and  associated  documentation files  (the
-"Software"), to  deal in  the Software without  restriction, including
-without limitation  the rights to  use, copy, modify,  merge, publish,
-distribute,  sublicense, and/or sell  copies of  the Software,  and to
-permit persons to whom the Software  is furnished to do so, subject to
-the following conditions:
-
-The  above  copyright  notice  and  this permission  notice  shall  be
-included in all copies or substantial portions of the Software.
-
-THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
-EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
-MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------- SECTION 3: Creative Commons Attribution 2.5  ----------
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
 
     <properties>
         <io.dropwizard.metrics5.version>5.0.0-rc3</io.dropwizard.metrics5.version>
-        <slf4j.version>1.7.32</slf4j.version>
         <java.version>1.8</java.version>
         <jackson.version>2.12.4</jackson.version>
     </properties>
@@ -197,12 +196,6 @@
             <groupId>io.dropwizard.metrics5</groupId>
             <artifactId>metrics-jvm</artifactId>
             <version>${io.dropwizard.metrics5.version}</version>
-        </dependency>
-        <!-- For https://www.slf4j.org/codes.html#StaticLoggerBinder -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.wavefront</groupId>


### PR DESCRIPTION
`wavefront-internal-reporter-java` has a direct dependency on the `slf4j-nop`.
This causes an application to find multiple slf4j bindings when the application depends on a different slf4j binding.
When the noop binding is picked, no logs are printed on the application.

Since `wavefront-internal-reporter-java` is a library, it should not have a dependency on a particular slf4j binding.

It is also documented in [SLF4J documentation](http://www.slf4j.org/manual.html#libraries).

> Embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding but only depend on slf4j-api. When a library declares a transitive dependency on a specific binding, that binding is imposed on the end-user negating the purpose of SLF4J


This PR removes the direct dependency to the `slf4j-nop` since this library does not use any SLF4J APIs.
If this library needs to work with SLF4J, instead of specific binding implementation, it should use `slef4j-api`.

The dropwizard-metrics has a dependency on `slf4j-api`. So, transitively it has a dependency on `slf4j-api`.


After the removal, library dependencies become like this:

```
[INFO] com.wavefront:wavefront-internal-reporter-java:jar:1.7.7-SNAPSHOT
[INFO] +- io.dropwizard.metrics5:metrics-core:jar:5.0.0-rc3:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.27:compile
[INFO] +- io.dropwizard.metrics5:metrics-jvm:jar:5.0.0-rc3:compile
[INFO] +- com.wavefront:wavefront-sdk-java:jar:2.6.5:compile
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- com.tdunning:t-digest:jar:3.2:compile
[INFO] |  \- com.google.guava:guava:jar:30.1.1-jre:compile
[INFO] |     +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |     +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |     +- org.checkerframework:checker-qual:jar:3.8.0:compile
[INFO] |     +- com.google.errorprone:error_prone_annotations:jar:2.5.1:compile
[INFO] |     \- com.google.j2objc:j2objc-annotations:jar:1.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-annotations:jar:2.12.4:compile
[INFO] +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.12.4:compile
[INFO] |  +- org.yaml:snakeyaml:jar:1.27:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.12.4:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.12.4:compile
[INFO] \- junit:junit:jar:4.13.2:test
[INFO]    \- org.hamcrest:hamcrest-core:jar:1.3:test
```
