### PR TITLE
Move slf4j-nop to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,12 +198,6 @@
             <artifactId>metrics-jvm</artifactId>
             <version>${io.dropwizard.metrics5.version}</version>
         </dependency>
-        <!-- For https://www.slf4j.org/codes.html#StaticLoggerBinder -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>wavefront-sdk-java</artifactId>
@@ -228,6 +222,13 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- For https://www.slf4j.org/codes.html#StaticLoggerBinder -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/wavefront/config/ReportingUtils.java
+++ b/src/main/java/com/wavefront/config/ReportingUtils.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  */
 public class ReportingUtils {
   /**
-   * Construct {@link WavefrontSender) from {@link WavefrontReportingConfig}
+   * Construct {@link WavefrontSender} from {@link WavefrontReportingConfig}
    */
   public static WavefrontSender constructWavefrontSender(
       WavefrontReportingConfig wfReportingConfig) {


### PR DESCRIPTION
Keeping the dependency addresses the issue in #38 of noisy test output. However, we don't want to include the dependency for downstream consumers of this library.

Example output of running the tests when we remove `slf4j-nop` altogether:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.wavefront.internal.SpanDerivedMetricsUtilsTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
<truncated>
```
