### PR TITLE
override snakeyaml (CVE-2022-38752)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,13 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <!-- CVE-2022-38752: Override vulnerable snakeyaml in jackson-dataformat-yaml.
+             Remove snakeyaml once jackson-dataformat-yaml 2.14 is released. -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.33</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
Override vulnerable snakeyaml in jackson-dataformat-yaml to address CVE. Remove this dependency once jackson 2.14 is released, which includes snakeyaml 1.32+: https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml.

MONIT-30763