### PR TITLE
Revert "MONIT-30763: override snakeyaml (CVE-2022-38752) (#121)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,13 +225,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-        <!-- CVE-2022-38752: Override vulnerable snakeyaml in jackson-dataformat-yaml.
-             Remove snakeyaml once jackson-dataformat-yaml 2.14 is released. -->
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
-        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
This reverts commit 71bcc60199255d3fed468d457aa1b0523ca03b9d.